### PR TITLE
add the list and ktool

### DIFF
--- a/ktool
+++ b/ktool
@@ -1,0 +1,208 @@
+#!/bin/bash
+# shellcheck disable=2166,2015,2039
+
+VERBOSITY=0
+TEMP_D=""
+
+stderr() { echo "$@" 1>&2; }
+fail() { local r=$?;  [ $r -eq 0 ] && r=1; failrc "$r" "$@"; }
+failrc() { local r="$1"; shift; [ $# -eq 0 ] || stderr "$@"; exit "$r"; }
+
+Usage() {
+    cat <<EOF
+Usage: ${0##*/} [ options ] <<ARGUMENTS>>
+
+   <<SUMMARY HERE>>
+
+   options:
+    -v | --verbose     increase verbosity.
+EOF
+}
+
+bad_Usage() { Usage 1>&2; [ $# -eq 0 ] || stderr "$@"; return 1; }
+cleanup() {
+    [ -z "${TEMP_D}" -o ! -d "${TEMP_D}" ] || rm -Rf "${TEMP_D}"
+}
+
+debug() {
+    local level=${1}; shift;
+    [ "${level}" -gt "${VERBOSITY}" ] && return
+    stderr "${@}"
+}
+
+rq() {
+    local r="" out="" cmd=""
+    cmd="$*"
+    if command -v shell-quote >/dev/null 2>&1; then
+        cmd=$(shell-quote "$@") ||
+            { stderr "shell-quote failed"; return 254; }
+    fi
+    stderr "execute: $cmd"
+    out=$("$@" 2>&1 </dev/null) && return 0
+    r=$?
+    stderr "$out"
+    stderr "failed [$r]"
+    return "$r"
+}
+
+gen_key() {
+    local out="$1"
+    rq openssl genrsa -out "$out" 2048 ||
+        fail "failed to generate key into $out"
+}
+
+gen_request() {
+    # generate request, creates base-key.pem and base-req.pem
+    local subj="$1" key="$2" out="$3"
+    rq openssl req \
+        -new \
+        -key "$key" \
+        -nodes \
+        -out "$out" \
+        -subj "/$subj/" ||
+        fail "failed generating req for $subj"
+}
+
+gen_ca() {
+    local subj="$1" key="$2" out="$3"
+    rq openssl req \
+        -new \
+        -key "$key" \
+        -nodes \
+        -out "$out" \
+        -subj "/$subj/" \
+        -days $((365*20)) \
+        -x509 ||
+        fail "failed generating CA"
+}
+
+sign_request() {
+    local req="$1" cert="$2" key="$3" out="$4" extensions="$5"
+    rq openssl x509 \
+        -req \
+        -days $((365*20)) \
+        -sha256 \
+        -in "$req" \
+        -CA "$cert" \
+        -CAkey "$key" \
+        -CAcreateserial \
+        -out "$out" \
+        ${extensions:+-extfile "${extensions}"} ||
+        fail "failed signing request from $req"
+}
+
+do_x509() {
+    local outd="${1%/}" guid="$2"
+    shift 2
+    local o="$1" ou="$2" cn="$3"
+	rm -Rf "$outd"
+    mkdir -p "$outd" || { error "failed to create $outd"; return 1; }
+    if [ -z "$guid" ]; then
+        guid=$(uuidgen) ||
+            { stderr "failed to gen uuid"; return 1; }
+    fi
+    gen_key "$outd/privkey.pem" || return
+    gen_ca "O=$o/OU=$ou/CN=$cn" "$outd/privkey.pem" "$outd/cert.pem" || return
+    printf "%s\n" "$guid" > "$outd/guid"
+}
+
+# manifest-csr | manifest/default        | manifest-ca/ , manifest     | bc564363-2a8e-44fe-bb0e-54c7f9988ecf
+do_manifestcsr() {
+    local outd="${1%/}" guid="$2" cad="$3" name="${4:-manifest}"
+    if [ -z "$guid" ]; then
+        guid=$(uuidgen) ||
+            { stderr "failed to gen uuid"; return 1; }
+    fi
+    gen_key "$outd/privkey.pem" || return
+    gen_request "CN=manifest PRODUCT:$guid" \
+        "$outd/privkey.pem" "$outd/csr.pem" || return
+    sign_request "$outd/csr.pem" \
+        "$cad/cert.pem" "$cad/privkey.pem" "$outd/cert.pem" ||
+        return
+    rq rm -f "$outd/csr.pem"
+}
+
+#sudi-csr     | manifest/default/sudi   | sudi-ca/ ,     manifest/default                               | 4cc76b82-948c-44b8-948c-1cc9a7d460d0
+# sudi#     CN = 4cc76b82-948c-44b8-948c-1cc9a7d460d0, serialNumber = PID:bc564363-2a8e-44fe-bb0e-54c7f9988ecf SN:4cc76b82-948c-44b8-948c-1cc9a7d460d0
+do_sudicsr() {
+    local outd="${1%/}" guid="$2" cad="$3" name="${4}"
+    local soutd=""
+    if [ -z "$guid" ]; then
+        guid=$(uuidgen) ||
+            { stderr "failed to gen uuid"; return 1; }
+    fi
+    local cadguid=""
+    cadguid=$(cat "$cad/guid") || {
+        stderr "failed to read guid from $outd/guid"
+        return 1
+    }
+    soutd="$outd/$guid"
+    rm -Rf "$soutd" && mkdir "$soutd" || return
+    gen_key "$soutd/privkey.pem" || return
+    #    Issuer: O = Cisco, OU = PuzzleOS Machine Project snakeoil, CN = Sudi rootCA
+    #    Subject: CN = 4cc76b82-948c-44b8-948c-1cc9a7d460d0, serialNumber = PID:bc564363-2a8e-44fe-bb0e-54c7f9988ecf SN:4cc76b82-948c-44b8-948c-1cc9a7d460d0
+    gen_request "CN=$guid/SerialNumber=PID:$cadguid SN:$guid" \
+        "$soutd/privkey.pem" "$soutd/csr.pem" || return
+    sign_request "$soutd/csr.pem" \
+        "$cad/cert.pem" "$cad/privkey.pem" "$soutd/cert.pem" ||
+        return
+    rq rm -f "$soutd/csr.pem"
+    return 0
+}
+
+main() {
+    local sopts="hv"
+    local lopts="help,verbose"
+    local name="${0##*/}" input=""
+    out=$(getopt --name "$name" \
+        --options "$sopts" --long "$lopts" -- "$@") &&
+        eval set -- "$out" ||
+        { bad_Usage; return; }
+
+    local cur="" next="" output=""
+
+    while [ $# -ne 0 ]; do
+        cur="$1"; next="$2";
+        case "$cur" in
+            -h|--help) Usage ; exit 0;;
+            -v|--verbose) VERBOSITY=$((VERBOSITY+1));;
+            --) shift; break;;
+        esac
+        shift;
+    done
+
+    [ $# -ne 0 ] || { bad_Usage "must provide input"; return; }
+
+    TEMP_D=$(mktemp -d "${TMPDIR:-/tmp}/${0##*/}.XXXXXX") ||
+        fail "failed to make tempdir"
+    trap cleanup EXIT
+
+    input="$1"
+    set --
+    OIFS="$IFS"
+    while read line; do
+        [ "${line#"#"*}" = "$line" ] || continue
+        line=$(echo "$line" | sed 's/[ ]*|[ ]*/|/g')
+        IFS="|" ; set -- $line ; IFS="$OIFS"
+        mode="$1"
+        out="$2"
+        fields="$3"
+        guid="$4"
+        fields=$(echo "$fields" | sed 's/[ ]*,[ ]*/,/g')
+        IFS=","; set -- $fields; IFS="$OIFS"
+        case "$mode" in
+            x509-guid|x509)
+                do_x509 "$out" "$guid" "$@" || fail;;
+            manifest-csr)
+                do_manifestcsr "$out" "$guid" "$@" || fail;;
+            sudi-csr)
+                do_sudicsr "$out" "$guid" "$@" || fail
+                ;;
+            *) fail "unknown mode $mode"
+                ;;
+        esac
+    done < "$input"
+}
+
+main "$@"
+# vi: ts=4 expandtab

--- a/list
+++ b/list
@@ -1,0 +1,16 @@
+# dir   | type      |  O / OU / CN | guid
+# manifest-csr are signed by manifest-ca
+x509-guid    | uefi-pk/                | Cisco , PuzzleOS Machine Project snakeoil , UEFI PK           | 13ef5459-35fe-49aa-91ab-a6b0391f0a2a
+x509-guid    | uefi-kek/               | Cisco , PuzzleOS Machine Project snakeoil , UEFI KEK          | 55c5bba5-e3ea-4594-b53b-6308ed23c4a9
+x509-guid    | uefi-db/                | Cisco , PuzzleOS Machine Project snakeoil , UEFI DB           | 326aa6de-a82d-4fd7-8015-2db804aea8e7
+x509-guid    | uki-limited/            | Cisco , PuzzleOS Machine Project snakeoil , UKI Limited       | c31227a6-4f70-4525-9348-62c18d5c0240
+x509-guid    | uki-production/         | Cisco , PuzzleOS Machine Project snakeoil , UKI Production    | 7b42b67c-4fc9-41e9-ae7a-b8d9134835ad
+x509-guid    | uki-tpm/                | Cisco , PuzzleOS Machine Project snakeoil , UKI TPM           | 617e599e-4f07-47fa-9504-fe4ae1616c83
+x509         | tpm-admin/              | Cisco , PuzzleOS Machine Project snakeoil , TPM EAPolicy LUKS | 
+x509         | tpm-luks/               | Cisco , PuzzleOS Machine Project snakeoil , TPM EAPolicy LUKS | 
+x509         | manifest-ca/            | Cisco , PuzzleOS Machine Project snakeoil , Manifest rootCA   | 
+x509         | sudi-ca/                | Cisco , PuzzleOS Machine Project snakeoil , Sudi rootCA       | 
+manifest-csr | manifest/default        | manifest-ca/ , manifest                                       | bc564363-2a8e-44fe-bb0e-54c7f9988ecf
+sudi-csr     | manifest/default/sudi   | sudi-ca/ ,     manifest/default                               | 4cc76b82-948c-44b8-948c-1cc9a7d460d0
+# manifest# CN = manifest PRODUCT:bc564363-2a8e-44fe-bb0e-54c7f9988ecf
+# sudi#     CN = 4cc76b82-948c-44b8-948c-1cc9a7d460d0, serialNumber = PID:bc564363-2a8e-44fe-bb0e-54c7f9988ecf SN:4cc76b82-948c-44b8-948c-1cc9a7d460d0


### PR DESCRIPTION
looking for feedback.

the script here generates all these files, so its easy to change something and/or regenerate them.

to my knowledge there wasn't anything that did this already.

```
$ ./ktool list
execute: openssl genrsa -out uefi-pk/privkey.pem 2048
execute: openssl req -new -key uefi-pk/privkey.pem -nodes -out uefi-pk/cert.pem -subj '/O=Cisco/OU=PuzzleOS Machine Project snakeoil/CN=UEFI PK/' -days 7300 -x509
execute: openssl genrsa -out uefi-kek/privkey.pem 2048
execute: openssl req -new -key uefi-kek/privkey.pem -nodes -out uefi-kek/cert.pem -subj '/O=Cisco/OU=PuzzleOS Machine Project snakeoil/CN=UEFI KEK/' -days 7300 -x509
execute: openssl genrsa -out uefi-db/privkey.pem 2048
execute: openssl req -new -key uefi-db/privkey.pem -nodes -out uefi-db/cert.pem -subj '/O=Cisco/OU=PuzzleOS Machine Project snakeoil/CN=UEFI DB/' -days 7300 -x509
execute: openssl genrsa -out uki-limited/privkey.pem 2048
execute: openssl req -new -key uki-limited/privkey.pem -nodes -out uki-limited/cert.pem -subj '/O=Cisco/OU=PuzzleOS Machine Project snakeoil/CN=UKI Limited/' -days 7300 -x509
execute: openssl genrsa -out uki-production/privkey.pem 2048
execute: openssl req -new -key uki-production/privkey.pem -nodes -out uki-production/cert.pem -subj '/O=Cisco/OU=PuzzleOS Machine Project snakeoil/CN=UKI Production/' -days 7300 -x509
execute: openssl genrsa -out uki-tpm/privkey.pem 2048
execute: openssl req -new -key uki-tpm/privkey.pem -nodes -out uki-tpm/cert.pem -subj '/O=Cisco/OU=PuzzleOS Machine Project snakeoil/CN=UKI TPM/' -days 7300 -x509
execute: openssl genrsa -out tpm-admin/privkey.pem 2048
execute: openssl req -new -key tpm-admin/privkey.pem -nodes -out tpm-admin/cert.pem -subj '/O=Cisco/OU=PuzzleOS Machine Project snakeoil/CN=TPM EAPolicy LUKS/' -days 7300 -x509
execute: openssl genrsa -out tpm-luks/privkey.pem 2048
execute: openssl req -new -key tpm-luks/privkey.pem -nodes -out tpm-luks/cert.pem -subj '/O=Cisco/OU=PuzzleOS Machine Project snakeoil/CN=TPM EAPolicy LUKS/' -days 7300 -x509
execute: openssl genrsa -out manifest-ca/privkey.pem 2048
execute: openssl req -new -key manifest-ca/privkey.pem -nodes -out manifest-ca/cert.pem -subj '/O=Cisco/OU=PuzzleOS Machine Project snakeoil/CN=Manifest rootCA/' -days 7300 -x509
execute: openssl genrsa -out sudi-ca/privkey.pem 2048
execute: openssl req -new -key sudi-ca/privkey.pem -nodes -out sudi-ca/cert.pem -subj '/O=Cisco/OU=PuzzleOS Machine Project snakeoil/CN=Sudi rootCA/' -days 7300 -x509
execute: openssl genrsa -out manifest/default/privkey.pem 2048
execute: openssl req -new -key manifest/default/privkey.pem -nodes -out manifest/default/csr.pem -subj '/CN=manifest PRODUCT:bc564363-2a8e-44fe-bb0e-54c7f9988ecf/'
execute: openssl x509 -req -days 7300 -sha256 -in manifest/default/csr.pem -CA manifest-ca//cert.pem -CAkey manifest-ca//privkey.pem -CAcreateserial -out manifest/default/cert.pem
execute: rm -f manifest/default/csr.pem
execute: openssl genrsa -out manifest/default/sudi/4cc76b82-948c-44b8-948c-1cc9a7d460d0/privkey.pem 2048
execute: openssl req -new -key manifest/default/sudi/4cc76b82-948c-44b8-948c-1cc9a7d460d0/privkey.pem -nodes -out manifest/default/sudi/4cc76b82-948c-44b8-948c-1cc9a7d460d0/csr.pem -subj '/CN=4cc76b82-948c-44b8-948c-1cc9a7d460d0/SerialNumber=PID:12e05d2b-a108-4c93-a728-536b34b52c34 SN:4cc76b82-948c-44b8-948c-1cc9a7d460d0/'
execute: openssl x509 -req -days 7300 -sha256 -in manifest/default/sudi/4cc76b82-948c-44b8-948c-1cc9a7d460d0/csr.pem -CA sudi-ca//cert.pem -CAkey sudi-ca//privkey.pem -CAcreateserial -out manifest/default/sudi/4cc76b82-948c-44b8-948c-1cc9a7d460d0/cert.pem
execute: rm -f manifest/default/sudi/4cc76b82-948c-44b8-948c-1cc9a7d460d0/csr.pem

```